### PR TITLE
Fix issue on Mac for adding secret for apps with spaces in name

### DIFF
--- a/SSOAutoSetup/src/configure/ssoAppDataSetttings.js
+++ b/SSOAutoSetup/src/configure/ssoAppDataSetttings.js
@@ -13,7 +13,7 @@ function addSecretToCredentialStore(ssoAppName, secret) {
                 break;
             case "darwin":
                 console.log(`Adding application secret for ${ssoAppName} to Mac OS Keychain`);
-                const addSecretToMacStoreCommand = `sudo security add-generic-password -a ${os.userInfo().username} -s ${ssoAppName} -w ${secret}`;
+                const addSecretToMacStoreCommand = `sudo security add-generic-password -a ${os.userInfo().username} -s "${ssoAppName}" -w "${secret}"`;
                 childProcess.execSync(addSecretToMacStoreCommand, { stdio: "pipe" });
                 break;
             default:


### PR DESCRIPTION
If the SSO application name has a space in it, adding a secret will fail on Mac. The fix is to put the app name in quotes